### PR TITLE
Fix minijinja tag format mismatch in clone step

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -100,7 +100,7 @@ jobs:
           body: |
             ## minijinja XCFramework v${{ steps.version.outputs.version }}
 
-            This release packages [minijinja v${{ steps.version.outputs.version }}](https://github.com/mitsuhiko/minijinja/releases/tag/v${{ steps.version.outputs.version }}) as an XCFramework.
+            This release packages [minijinja v${{ steps.version.outputs.version }}](https://github.com/mitsuhiko/minijinja/releases/tag/${{ steps.version.outputs.version }}) as an XCFramework.
 
             ### Installation
 

--- a/justfile
+++ b/justfile
@@ -160,7 +160,7 @@ clone-minijinja version=MINIJINJA_VERSION: clean
     if [ "{{version}}" == "main" ]; then
         git clone https://github.com/mitsuhiko/minijinja.git
     else
-        git clone --branch "v{{version}}" --depth 1 https://github.com/mitsuhiko/minijinja.git
+        git clone --branch "{{version}}" --depth 1 https://github.com/mitsuhiko/minijinja.git
     fi
 
     # Patch minijinja-cabi to build as staticlib and enable unicode feature


### PR DESCRIPTION
## Summary

Fixes the build-release workflow that has been failing since minijinja 2.12.0 was released.

The root cause was a tag format mismatch:
- Upstream minijinja uses tags **without** 'v' prefix: `2.12.0`
- This repository uses tags **with** 'v' prefix: `v2.12.0`
- The justfile was incorrectly adding 'v' when cloning from upstream, causing git clone to fail

## Changes

- **justfile:163** - Remove 'v' prefix from `git clone --branch` command
- **build-release.yml:103** - Fix markdown link to upstream minijinja releases to use correct tag format

## Testing

Verified that `git clone --branch "2.12.0"` successfully clones the upstream minijinja repository.

## Impact

After merging, the scheduled workflow should successfully:
1. Detect new minijinja releases (e.g., `2.12.0`)
2. Clone the correct tag from upstream  
3. Build the XCFramework
4. Create a release in this repo with tag `v2.12.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)